### PR TITLE
test (helpers) should not set a max execution time

### DIFF
--- a/src/app/Traits/SignIn.php
+++ b/src/app/Traits/SignIn.php
@@ -6,8 +6,6 @@ trait SignIn
 {
     protected function signIn($user = null)
     {
-        set_time_limit(30);
-
         $user = $user ?? factory('App\User')->create();
         $user->role_id = intval($user->role_id);
         $this->actingAs($user);


### PR DESCRIPTION
max_execution (may) prevent(s) generating code coverage reports, especially on slower machines.